### PR TITLE
Fix Query String Parameters Being Ignored

### DIFF
--- a/Sources/HttpApi/APIGatewayV2+HTTPRequest.swift
+++ b/Sources/HttpApi/APIGatewayV2+HTTPRequest.swift
@@ -18,13 +18,18 @@ import OpenAPIRuntime
 
 extension APIGatewayV2Request {
 
+    // OpenAPIGenerator expects the path to include the query string
+    var pathWithQueryString: String {
+        rawPath + (rawQueryString.isEmpty ? "" : "?\(rawQueryString)")
+    }
+
     /// Return an `HTTPRequest` for this `APIGatewayV2Request`
     public func httpRequest() throws -> HTTPRequest {
         HTTPRequest(
             method: self.context.http.method,
             scheme: "https",
             authority: "",
-            path: self.rawPath,
+            path: pathWithQueryString,
             headerFields: self.headers.httpFields()
         )
     }

--- a/Sources/Router/OpenAPILambdaRouterTrie.swift
+++ b/Sources/Router/OpenAPILambdaRouterTrie.swift
@@ -101,7 +101,7 @@ struct URIPath: URIPathCollection {
         }
 
         // search for each path component.  If a component is not found, it might be a parameter
-        let pathComponents = path.split(separator: "/")
+        let pathComponents = path.prefix(while: { $0 != "?" }).split(separator: "/")
         var currentNode = nodeHTTP
         for component in pathComponents {
             if let child = currentNode.child(with: component) {

--- a/Sources/Router/OpenAPILambdaRouterTrie.swift
+++ b/Sources/Router/OpenAPILambdaRouterTrie.swift
@@ -101,6 +101,7 @@ struct URIPath: URIPathCollection {
         }
 
         // search for each path component.  If a component is not found, it might be a parameter
+        // stop at the start of the query string
         let pathComponents = path.prefix(while: { $0 != "?" }).split(separator: "/")
         var currentNode = nodeHTTP
         for component in pathComponents {

--- a/Tests/OpenAPILambdaTests/Router/RouterGraphTest.swift
+++ b/Tests/OpenAPILambdaTests/Router/RouterGraphTest.swift
@@ -323,18 +323,26 @@ struct RouterGraphTests {
 
         //when
         #expect(throws: Never.self) { try graph.find(method: method, path: pathToTest) }
-        let (handler, metadata) = try graph.find(method: method, path: pathToTest)
+        let (handler, metadata) = try graph.find(method: method, path: pathToTest )
         #expect(metadata.count == 0)
         #expect(handler != nil)
     }
 
-    @Test("Find handler 2")
-    func testFindHandler2() throws {
+    @Test(
+        "Find handler 2",
+        arguments: [
+            "/element3/value1/element4",
+            "/element3/value2/element4",
+            "/element3/value1/element4?param1=value1"
+        ]
+    )
+    func testFindHandler2(
+        pathToTest: String
+    ) throws {
         // given
         let strMethod = "GET"
         let method = HTTPRequest.Method(strMethod)!
         let graph = prepareGraphForFind(for: method)
-        let pathToTest = "/element3/value1/element4"
 
         //when
         #expect(throws: Never.self) { try graph.find(method: method, path: pathToTest) }

--- a/Tests/OpenAPILambdaTests/Router/RouterGraphTest.swift
+++ b/Tests/OpenAPILambdaTests/Router/RouterGraphTest.swift
@@ -323,7 +323,7 @@ struct RouterGraphTests {
 
         //when
         #expect(throws: Never.self) { try graph.find(method: method, path: pathToTest) }
-        let (handler, metadata) = try graph.find(method: method, path: pathToTest )
+        let (handler, metadata) = try graph.find(method: method, path: pathToTest)
         #expect(metadata.count == 0)
         #expect(handler != nil)
     }
@@ -333,7 +333,7 @@ struct RouterGraphTests {
         arguments: [
             "/element3/value1/element4",
             "/element3/value2/element4",
-            "/element3/value1/element4?param1=value1"
+            "/element3/value1/element4?param1=value1",
         ]
     )
     func testFindHandler2(
@@ -345,10 +345,14 @@ struct RouterGraphTests {
         let graph = prepareGraphForFind(for: method)
 
         //when
-        #expect(throws: Never.self) { try graph.find(method: method, path: pathToTest) }
-        let (handler, metadata) = try graph.find(method: method, path: pathToTest)
-        #expect(metadata.count == 1)
-        #expect(handler != nil)
+        #expect(throws: Never.self) {
+            let (handler, metadata) = try graph.find(method: method, path: pathToTest)
+
+            // then (we can not test if the query string param have been decoded, that's the job of the openapi runtime.)
+            #expect(metadata.count == 1)
+            #expect(handler != nil)
+        }
+
     }
 
     @Test("Find handler 3")


### PR DESCRIPTION
## Issue

Query string parameters are dropped

## Details

The current implementation of this transport does not work with query string parameters. This is a fairly minimal change that fixes the functionality.

This change adds the query string parameters to the path in the `HTTPRequest`. Whether or not this is the right place for them can be answered by looking at the code generated by the Swift OpenAPI Generator. An example can be [found here](https://github.com/apple/swift-openapi-generator/blob/7b4dd6b781f8e3658f75273fc2a8d11767f119d7/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift).

```swift
    func listPets(
        request: HTTPTypes.HTTPRequest,
        body: OpenAPIRuntime.HTTPBody?,
        metadata: OpenAPIRuntime.ServerRequestMetadata
    ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
        try await handle(
            request: request,
            requestBody: body,
            metadata: metadata,
            forOperation: Operations.listPets.id,
            using: {
                APIHandler.listPets($0)
            },
            deserializer: { request, requestBody, metadata in
                let query: Operations.listPets.Input.Query = .init(
                    limit: try converter.getOptionalQueryItemAsURI(
                        in: request.soar_query,
                        style: .form,
                        explode: true,
                        name: "limit",
                        as: Swift.Int32.self
                    ),
```

The generated code calls `request.soar_query` from [OpenAPIRuntime](https://github.com/apple/swift-openapi-runtime/blob/daa2fb54fe4a7f5187d7286047d5144c8cb97477/Sources/OpenAPIRuntime/Interface/CurrencyTypes.swift#L42) which extracts the query string from the path in the `HTTPRequest`. This differs from other path parameters which are extracted from the `ServerRequestMetadata`.

```swift
    func updatePet(
        request: HTTPTypes.HTTPRequest,
        body: OpenAPIRuntime.HTTPBody?,
        metadata: OpenAPIRuntime.ServerRequestMetadata
    ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
        try await handle(
            request: request,
            requestBody: body,
            metadata: metadata,
            forOperation: Operations.updatePet.id,
            using: {
                APIHandler.updatePet($0)
            },
            deserializer: { request, requestBody, metadata in
                let path: Operations.updatePet.Input.Path = .init(petId: try converter.getPathParameterAsURI(
                    in: metadata.pathParameters,
                    name: "petId",
                    as: Swift.Int64.self
                ))
```

## Testing

I have also added updated the tests to verify that the routing is not broken by this change. I noticed you recently changed the tests to use the Swift Testing framework. The modification I made uses the arguments feature to try multiple values, but further refactoring of this type is also possible. There wasn't an existing setup with mocks to test the query string being passed all the way through but that would be another improvement possible. I have confirmed that the query string parameters do come through now end-to-end when used in a project.