### PR TITLE
Use explicit types

### DIFF
--- a/Sources/OpenAPILambda.swift
+++ b/Sources/OpenAPILambda.swift
@@ -72,7 +72,7 @@ extension OpenAPILambdaService {
             handler: LambdaHandlerAdapter(handler: try Self.makeHandler())
         )
 
-        let lambdaRuntime = LambdaRuntime(handler: handler, logger: _logger,)
+        let lambdaRuntime = LambdaRuntime(handler: handler, logger: _logger)
         try await lambdaRuntime.run()
     }
 }

--- a/Sources/OpenAPILambdaHandler.swift
+++ b/Sources/OpenAPILambdaHandler.swift
@@ -18,7 +18,7 @@ import OpenAPIRuntime
 import HTTPTypes
 
 /// Specialization of LambdaHandler which runs an OpenAPILambda
-public struct OpenAPILambdaHandler<OALS: OpenAPILambdaService>: Sendable {
+public struct OpenAPILambdaHandler<OALS: OpenAPILambdaService>: LambdaHandler {
 
     private let router: OpenAPILambdaRouter
     private let transport: OpenAPILambdaTransport
@@ -65,7 +65,7 @@ public struct OpenAPILambdaHandler<OALS: OpenAPILambdaService>: Sendable {
     ///     - context: Runtime ``LambdaContext``.
     ///
     /// - Returns: A Lambda result ot type `Output`.
-    public func handler(event: OALS.Event, context: LambdaContext) async throws -> OALS.Output {
+    public func handle(_ event: OALS.Event, context: AWSLambdaRuntime.LambdaContext) async throws -> OALS.Output {
 
         // by default returns HTTP 500
         var lambdaResponse: OpenAPILambdaResponse = (HTTPResponse(status: .internalServerError), "unknown error")


### PR DESCRIPTION
We can make compilation and reasoning for the developers easier by using explicit types throughout.