### PR TITLE
Apply recommendation for security and reliability

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+# As per Checkov CKV2_GHA_1
+permissions: read-all
+
 jobs:
   soundness:
     name: Soundness

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ DerivedData/
 .swiftpm/config/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 *key
+.ash

--- a/Examples/quoteapi/Makefile
+++ b/Examples/quoteapi/Makefile
@@ -49,6 +49,7 @@ builder-bot:
 	docker build -f Dockerfile . -t swift-builder
 
 	# prep directories
+	rm -rf $($@ARTIFACTS_DIR)
 	mkdir -p $($@BUILD_DIR)/lambda $($@ARTIFACTS_DIR)
 
 	# compile application inside Docker image using source code from local project folder
@@ -58,8 +59,9 @@ builder-bot:
 	# create lambda bootstrap file
 	docker run --rm -v $($@BUILD_DIR):/build-target -v `pwd`:/build-src -w /build-src swift-builder bash -cl "cd /build-target/lambda && ln -s $($@PRODUCT) /bootstrap"
   
-	# copy binary to stage
-	cp $($@BUILD_DIR)/release/$($@PRODUCT) $($@STAGE)/bootstrap
+	# copy binary to artifacts dir
+	cp $($@BUILD_DIR)/release/$($@PRODUCT) $($@ARTIFACTS_DIR)/bootstrap
+
+	# copy resources to artifacts dir
+	[ -d "$($@BUILD_DIR)/release/$($@PRODUCT)_$($@PRODUCT).resources" ] && cp $($@BUILD_DIR)/release/$($@PRODUCT)_$($@PRODUCT).resources/* $($@ARTIFACTS_DIR) || true
   
-  	# copy app from stage to artifacts dir
-	cp $($@STAGE)/* $($@ARTIFACTS_DIR)

--- a/Examples/quoteapi/README.md
+++ b/Examples/quoteapi/README.md
@@ -2,7 +2,6 @@
 
 This application illustrates how to deploy a Server-Side Swift workload on AWS using the [AWS Serverless Application Model (SAM)](https://aws.amazon.com/serverless/sam/) toolkit. The workload is a simple REST API that returns a string from an Amazon API Gateway. Requests to the API Gateway endpoint are handled by an AWS Lambda Function written in Swift.
 
-
 ## Prerequisites
 
 To build this sample application, you need:
@@ -81,3 +80,20 @@ When finished with your application, use SAM to delete it from your AWS account.
 ```bash
 sam delete
 ```
+
+## ⚠️ Security and Reliability Notice
+
+This is an example application for demonstration purposes. When deploying such infrastructure in production environments, we strongly encourage you to follow these best practices for improved security and resiliency:
+
+- Enable access logging on API Gateway ([documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html))
+- Ensure that AWS Lambda function is configured for function-level concurrent execution limit ([concurrency documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-concurrency.html), [configuration guide](https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html))
+- Check encryption settings for Lambda environment variables ([documentation](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars-encryption.html))
+- Ensure that AWS Lambda function is configured for a Dead Letter Queue (DLQ) ([documentation](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async-retain-records.html#invocation-dlq))
+- Ensure that AWS Lambda function is configured inside a VPC when it needs to access private resources ([documentation](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html), [code example](https://github.com/swift-server/swift-aws-lambda-runtime/tree/main/Examples/ServiceLifecycle%2BPostgres))
+
+**Note:** The `openapi.yaml` file in this example is not suited for production. In real-world scenarios, you must:
+1. Ensure that the global security field has rules defined
+2. Ensure that security operations is not empty ([OpenAPI Security Specification](https://learn.openapis.org/specification/security.html))
+3. Follow proper authentication, authorization, input validation, and error handling practices
+
+As per Checkov CKV_OPENAPI_4 and CKV_OPENAPI_5 security checks.

--- a/Examples/quoteapi/Sources/QuoteAPI/openapi.yaml
+++ b/Examples/quoteapi/Sources/QuoteAPI/openapi.yaml
@@ -1,8 +1,20 @@
+# This is an example API definition not suited for production 
+#
+# In real life scenario, you must 
+# 1. Ensure that the global security field has rules defined
+# 2. Ensure that security operations is not empty.
+#    https://learn.openapis.org/specification/security.html
+#
+# As per Checkov CKV_OPENAPI_4 and CKV_OPENAPI_5
+
 openapi: 3.1.0
 info:
   title: StockQuoteService
   version: 1.0.0
-  
+
+# security:
+#   - defaultApiKey: []
+
 components:
   schemas:
     quote:
@@ -54,3 +66,5 @@ paths:
           description: Authentication required
         404:
           description: Not Found
+      # security:
+      #   - defaultApiKey: []

--- a/Examples/quoteapi/template.yml
+++ b/Examples/quoteapi/template.yml
@@ -2,6 +2,22 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: SAM Template for QuoteService
 
+# This is an example SAM template for the purpose of this project.
+# When deploying such infrastructure in production environment,
+# we strongly encourage you to follow these best practices for improved security and resiliency
+# - Enable access loggin on API Gateway
+#   See: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html)
+# - Ensure that AWS Lambda function is configured for function-level concurrent execution limit
+#   See: https://docs.aws.amazon.com/lambda/latest/dg/lambda-concurrency.html
+#        https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html
+# - Check encryption settings for Lambda environment variable
+#   See: https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars-encryption.html
+# - Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
+#   See: https://docs.aws.amazon.com/lambda/latest/dg/invocation-async-retain-records.html#invocation-dlq
+# - Ensure that AWS Lambda function is configured inside a VPC when it needs to access private resources
+#   See: https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html
+#   Code Example: https://github.com/swift-server/swift-aws-lambda-runtime/tree/main/Examples/ServiceLifecycle%2BPostgres
+     
 Globals:
   Function:
     Timeout: 60


### PR DESCRIPTION
Apply recommendations in code and documentation

- [CI] restrict permissions to `read-all` instead of the default `write-all` 
- Example `openapi.yaml` : add a note about using `security:` definition when deploying to production 
- Example `README.md` : add a note about Lambda functions configuration with improved security and scalability changes for production environment